### PR TITLE
Make a minor adjustment to the sidebar (see desc)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
+html_theme_options = {
+    "collapse_navigation": False,
+}
 html_logo = 'icon.png'
 html_favicon = 'icon.png'
 


### PR DESCRIPTION
With this simple change, you'll be able to expand items on the sidebar with the plus button. Before, this plus button only appeared if you selected that item. I like this way better because you can more easily use the sidebar.
