### PR TITLE
Improve library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-*.pyc
+*.py[cod]
 docs/_build
 build/*
 dist/*
 telegram.py.egg-info/*
+.python-version

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include requirements.txt
+include telegrampy/py.typed

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -13,7 +13,7 @@ bot = commands.Bot("token here")
 # Create and register a simple command called "hi"
 # This is invoked with "/hi" and the bot will respond with "Hello"
 @bot.command()
-async def hi(ctx):
+async def hi(ctx: commands.Context):
     await ctx.send("Hello")
 
 # Start polling updates from Telegram

--- a/examples/picture.py
+++ b/examples/picture.py
@@ -1,3 +1,4 @@
+import io
 import logging
 
 import telegrampy
@@ -11,12 +12,15 @@ bot = commands.Bot("token here")
 
 
 @bot.command(name="image")
-async def image_command(ctx):
+async def image_command(ctx: commands.Context):
     # Send the action 'upload_photo'
     await ctx.send_action("upload_photo")
 
     # Open an image and send it to the chat
-    with open("file path here", "rb") as photo:
-        await ctx.send_photo(photo, filename="photo.png", capton="This is a photo")
+    with open("file path here", "rb") as file:
+        content = file.read()
+        photo = io.BytesIO(content)
+
+    await ctx.send_photo(photo, filename="photo.png", caption="This is a photo")
 
 bot.run()

--- a/examples/poll.py
+++ b/examples/poll.py
@@ -10,7 +10,7 @@ bot = commands.Bot("token here")
 
 
 @bot.command()
-async def poll(ctx):
+async def poll(ctx: commands.Context):
     await ctx.send_poll(question="What is your favorite pet?", options=["Dogs", "Cats"])
 
 bot.run()

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     },
     version=version,
     lisence="MIT",
-    packages=["telegrampy", "telegrampy/ext/commands"],
+    packages=["telegrampy", "telegrampy.types", "telegrampy/ext/commands"],
     install_requires=requirements,
     extras_require={
         "docs": [

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setuptools.setup(
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Utilities"
+        "Topic :: Utilities",
+        "Typing :: Typed",
     ],
     python_requires=">=3.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
     version=version,
     lisence="MIT",
     packages=["telegrampy", "telegrampy.types", "telegrampy/ext/commands"],
+    include_package_data=True,
     install_requires=requirements,
     extras_require={
         "docs": [

--- a/telegrampy/__init__.py
+++ b/telegrampy/__init__.py
@@ -25,4 +25,4 @@ from .poll import *
 
 VersionInfo = namedtuple("VersionInfo", "major minor micro releaselevel serial")
 
-version_info = VersionInfo(major=0, minor=4, micro=0, releaselevel="alpha", serial=0)
+version_info: VersionInfo = VersionInfo(major=0, minor=4, micro=0, releaselevel="alpha", serial=0)

--- a/telegrampy/abc.py
+++ b/telegrampy/abc.py
@@ -24,35 +24,14 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from .mixins import Hashable
-
-from typing import (
-    Any,
-    Dict,
-    SupportsInt,
-    TYPE_CHECKING,
-    Union,
-)
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .http import HTTPClient
 
-    SupportsIntCast = Union[SupportsInt, str]
 
-
-class TelegramObject(Hashable):
+class TelegramObject:
     """Base telegram object."""
 
-    def __init__(self, http: HTTPClient, data: Any) -> None:
-        self._http = http
-
-        _id = data.get("id")
-        if not _id:
-            raise TypeError("data doesn't have an id key")
-
-        try:
-            id = int(_id)
-        except ValueError:
-            raise TypeError(f'id parameter must be convertable to int not {_id.__class__!r}') from None
-        else:
-            self.id = id
+    def __init__(self, http: HTTPClient) -> None:
+        self._http: HTTPClient = http

--- a/telegrampy/abc.py
+++ b/telegrampy/abc.py
@@ -22,19 +22,34 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-class TelegramObject:
+from .http import HTTPClient
+from .mixins import Hashable
+
+from typing import (
+    Any,
+    Dict,
+    SupportsInt,
+    TYPE_CHECKING,
+    Union,
+)
+
+if TYPE_CHECKING:
+    SupportsIntCast = Union[SupportsInt, str]
+
+
+class TelegramObject(Hashable):
     """Base telegram object."""
 
-    def __init__(self, http, data):
+    def __init__(self, http: HTTPClient, data: Any) -> None:
         self._http = http
-        self._data = data
 
-        self.id = data.get("id")
+        _id = data.get("id")
+        if not _id:
+            raise TypeError("data doesn't have an id key")
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.id  == other.id
-
-    def __ne__(self, other):
-        if isinstance(other, self.__class__):
-            return other.id != self.id
-        return True
+        try:
+            id = int(_id)
+        except ValueError:
+            raise TypeError(f'id parameter must be convertable to int not {_id.__class__!r}') from None
+        else:
+            self.id = id

--- a/telegrampy/abc.py
+++ b/telegrampy/abc.py
@@ -22,7 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from .http import HTTPClient
+from __future__ import annotations
+
 from .mixins import Hashable
 
 from typing import (
@@ -34,6 +35,8 @@ from typing import (
 )
 
 if TYPE_CHECKING:
+    from .http import HTTPClient
+
     SupportsIntCast = Union[SupportsInt, str]
 
 

--- a/telegrampy/chat.py
+++ b/telegrampy/chat.py
@@ -28,7 +28,6 @@ import asyncio
 import io
 
 from .errors import *
-from .http import HTTPClient
 from .message import Message
 from .abc import TelegramObject
 from .poll import Poll
@@ -46,6 +45,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
+    from .http import HTTPClient
     from .utils import ParseMode
     from .types.chat import Chat as ChatPayload
 

--- a/telegrampy/chat.py
+++ b/telegrampy/chat.py
@@ -26,18 +26,15 @@ from __future__ import annotations
 
 import asyncio
 import io
+from optparse import Option
 
-from .errors import *
-from .message import Message
 from .abc import TelegramObject
-from .poll import Poll
-from .user import User
+from .errors import *
+from .mixins import Hashable
 
 from typing import (
     Any,
-    Dict,
     List,
-    Literal,
     Optional,
     TypeVar,
     Union,
@@ -46,6 +43,9 @@ from typing import (
 
 if TYPE_CHECKING:
     from .http import HTTPClient
+    from .message import Message
+    from .poll import Poll
+    from .user import User
     from .utils import ParseMode
     from .types.chat import Chat as ChatPayload
 
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 ChatActionSenderT = TypeVar("ChatActionSenderT", bound="ChatActionSender")
 
 
-class Chat(TelegramObject):
+class Chat(TelegramObject, Hashable):
     """
     Represents a chat in Telegram.
 
@@ -76,28 +76,36 @@ class Chat(TelegramObject):
     ----------
     id: :class:`int`
         The ID of the chat.
-    title: :class:`str`
-        The title of the chat.
-    description: Optional[:class:`str`]
-        The description of the chat.
     type: :class:`str`
         The type of the chat.
+    title: Optional[:class:`str`]
+        The title of the chat, if applicable..
+    username: Optional[:class:`str`]
+        The username of the chat, if applicable.
+    description: Optional[:class:`str`]
+        The description of the chat, if applicable.
+    invite_link: Optional[:class:`str`]
+        The invite link of the chat, if applicable.
     """
 
     if TYPE_CHECKING:
-        title: str
-        username: str
-        description: str
-        type: int
+        id: int
+        title: Optional[str]
+        username: Optional[str]
+        description: Optional[str]
+        type: str
+        invite_link: Optional[str]
 
     def __init__(self, http: HTTPClient, data: ChatPayload) -> None:
-        super().__init__(http, data)
-        self.title: str = data.pop("title")
-        self.username: str = data.pop("username")
-        self.description: str = data.pop("description")
-        self.type: int = data.pop("type")
+        super().__init__(http)
+        self.id: int = data.get("id")
+        self.title: Optional[str] = data.get("title")
+        self.username: Optional[str] = data.get("username")
+        self.description: Optional[str] = data.get("description")
+        self.type: str = data.get("type")
+        self.invite_link: Optional[str] = data.get("invite_link")
 
-    def __str__(self) -> str:
+    def __str__(self) -> Optional[str]:
         return self.title
 
     async def send(self, content: str, parse_mode: Optional[ParseMode] = None) -> Message:

--- a/telegrampy/chat.py
+++ b/telegrampy/chat.py
@@ -26,19 +26,17 @@ from __future__ import annotations
 
 import asyncio
 import io
-from optparse import Option
 
 from .abc import TelegramObject
-from .errors import *
 from .mixins import Hashable
 
 from typing import (
+    TYPE_CHECKING,
     Any,
     List,
     Optional,
     TypeVar,
     Union,
-    TYPE_CHECKING
 )
 
 if TYPE_CHECKING:
@@ -49,13 +47,11 @@ if TYPE_CHECKING:
     from .utils import ParseMode
     from .types.chat import Chat as ChatPayload
 
-
 ChatActionSenderT = TypeVar("ChatActionSenderT", bound="ChatActionSender")
 
 
 class Chat(TelegramObject, Hashable):
-    """
-    Represents a chat in Telegram.
+    """Represents a chat in Telegram.
 
     .. container:: operations
 
@@ -247,8 +243,7 @@ class Chat(TelegramObject, Hashable):
         await self._http.send_chat_action(chat_id=self.id, action=action)
 
     def action(self, action: str) -> ChatActionSender:
-        """
-        Returns a context manager that sends a chat action until the with statment is completed.
+        """Returns a context manager that sends a chat action until the with statement is completed.
 
         Parameters
         ----------

--- a/telegrampy/client.py
+++ b/telegrampy/client.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import traceback
 import sys
-from typing import Any, TYPE_CHECKING, Callable, Coroutine, Dict, List, Optional, Tuple, TypeVar
+import traceback
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Optional, Tuple, TypeVar
 
 from .errors import InvalidToken, Conflict
 from .http import HTTPClient
@@ -38,8 +38,8 @@ from .poll import Poll, PollAnswer
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec
 
-    from .user import User
     from .chat import Chat
+    from .user import User
 
     P = ParamSpec("P")
 
@@ -48,14 +48,11 @@ if TYPE_CHECKING:
     Coro = Coroutine[Any, Any, T]
     CoroFunc = Callable[..., Coro[Any]]
 
-
-
 log: logging.Logger = logging.getLogger("telegrampy")
 
 
 class Client:
-    """
-    Represents a client connection to Telegram.
+    """Represents a client connection to Telegram.
 
     Parameters
     ----------
@@ -138,7 +135,7 @@ class Client:
         log.info("Fetching unread updates")
         try:
             updates = await self.http.get_updates(offset=self._last_update_id)
-        except Exception as exc:
+        except Exception:
             raise
         else:
             if updates:
@@ -156,9 +153,9 @@ class Client:
             # Fetch updates
             try:
                 updates = await self.http.get_updates(offset=self._last_update_id, timeout=self._wait)
-            except (InvalidToken, Conflict) as exc:
+            except (InvalidToken, Conflict):
                 raise
-            except Exception as exc:
+            except Exception:
                 if self._running:
                     if tries < 30:
                         tries += 1
@@ -293,8 +290,7 @@ class Client:
         return await asyncio.wait_for(future, timeout=timeout)
 
     def event(self, func: CoroFunc) -> CoroFunc:
-        """
-        Turns a function into an event handler.
+        """Turns a function into an event handler.
 
         Parameters
         ----------
@@ -306,8 +302,7 @@ class Client:
         return func
 
     def add_listener(self, func: CoroFunc, name: str = None) -> None:
-        """
-        Registers a function as a listener.
+        """Registers a function as a listener.
 
         Parameters
         ----------
@@ -325,8 +320,7 @@ class Client:
             self._listeners[name] = [func]
 
     def remove_listener(self, func: CoroFunc) -> None:
-        """
-        Removes a listener.
+        """Removes a listener.
 
         Parameters
         ----------
@@ -339,8 +333,7 @@ class Client:
                 self._listeners[event].remove(func)
 
     def listen(self, name: str = None) -> Callable[[CoroFunc], CoroFunc]:
-        """
-        A decorator that registers a function as a listener.
+        """A decorator that registers a function as a listener.
 
         Parameters
         ---------
@@ -362,6 +355,7 @@ class Client:
 
     async def start(self) -> None:
         """|coro|
+
         Starts the bot.
         """
 
@@ -375,6 +369,7 @@ class Client:
 
     async def stop(self) -> None:
         """|coro|
+
         Stops the bot.
         """
 
@@ -399,9 +394,7 @@ class Client:
         self.loop.run_until_complete(self.loop.shutdown_asyncgens())
 
     def run(self) -> None:
-        """
-        Runs the bot.
-        """
+        """Runs the bot."""
 
         self._running = True
 

--- a/telegrampy/client.py
+++ b/telegrampy/client.py
@@ -22,12 +22,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import traceback
 import sys
 from typing import Any, TYPE_CHECKING, Callable, Coroutine, Dict, List, Optional, Tuple, TypeVar
-from typing_extensions import ParamSpec
 
 from .errors import InvalidToken, Conflict
 from .http import HTTPClient
@@ -35,6 +36,8 @@ from .message import Message
 from .poll import Poll, PollAnswer
 
 if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
     from .user import User
     from .chat import Chat
 

--- a/telegrampy/client.py
+++ b/telegrampy/client.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 
 
 
-log = logging.getLogger("telegrampy")
+log: logging.Logger = logging.getLogger("telegrampy")
 
 
 class Client:

--- a/telegrampy/errors.py
+++ b/telegrampy/errors.py
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from __future__ import annotations
+
 from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/telegrampy/errors.py
+++ b/telegrampy/errors.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     import aiohttp
@@ -33,11 +33,9 @@ if TYPE_CHECKING:
 class TelegramException(Exception):
     """Base exception for all errors."""
 
-    pass
 
 class HTTPException(TelegramException):
-    """
-    Raised when an HTTP request fails.
+    """Raised when an HTTP request fails.
 
     This inherits from :exc:`telegrampy.TelegramException`.
 
@@ -54,47 +52,37 @@ class HTTPException(TelegramException):
         self.message = message
         super().__init__(f"{response.status} {message}")
 
+
 class BadRequest(HTTPException):
-    """
-    Raised when a bad request is made.
+    """Raised when a bad request is made.
 
     This inherits from :exc:`telegrampy.HTTPException`.
     """
 
-    pass
 
 class InvalidToken(HTTPException):
-    """
-    Raised when a token is invalid.
+    """Raised when a token is invalid.
 
     This inherits from :exc:`telegrampy.HTTPException`.
     """
 
-    pass
 
 class Forbidden(HTTPException):
-    """
-    Raised when something is forbidden.
+    """Raised when something is forbidden.
 
     This inherits from :exc:`telegrampy.HTTPException`.
     """
 
-    pass
 
 class Conflict(HTTPException):
-    """
-    Raised when another instance of the bot is running.
+    """Raised when another instance of the bot is running.
 
     This inherits from :exc:`telegrampy.HTTPException`.
     """
 
-    pass
 
 class ServerError(HTTPException):
-    """
-    Raised when telegram returns a 500 error.
+    """Raised when telegram returns a 500 error.
 
     This inherits from :exc:`telegrampy.HTTPException`.
     """
-
-    pass

--- a/telegrampy/errors.py
+++ b/telegrampy/errors.py
@@ -22,6 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiohttp
+
+
 class TelegramException(Exception):
     """Base exception for all errors."""
 
@@ -41,7 +47,7 @@ class HTTPException(TelegramException):
        The message for the request that failed.
     """
 
-    def __init__(self, response, message):
+    def __init__(self, response: aiohttp.ClientResponse, message: Optional[str]):
         self.response = response
         self.message = message
         super().__init__(f"{response.status} {message}")
@@ -90,4 +96,3 @@ class ServerError(HTTPException):
     """
 
     pass
-    

--- a/telegrampy/ext/commands/bot.py
+++ b/telegrampy/ext/commands/bot.py
@@ -40,7 +40,6 @@ from typing import (
     TypeVar,
     Union
 )
-from typing_extensions import ParamSpec, Concatenate
 
 import telegrampy
 from .errors import *
@@ -50,6 +49,8 @@ from .context import Context
 from .help import HelpCommand, DefaultHelpCommand
 
 if TYPE_CHECKING:
+    from typing_extensions import ParamSpec, Concatenate
+
     from telegrampy import Message
 
     T = TypeVar("T")

--- a/telegrampy/ext/commands/bot.py
+++ b/telegrampy/ext/commands/bot.py
@@ -418,7 +418,7 @@ class Bot(telegrampy.Client):
                 Callable[Concatenate[ContextT, P], Coro[T]],
             ]
         ], Command[CogT, P, T]]:
-        """
+        r"""
         Turns a function into a command.
 
         Parameters

--- a/telegrampy/ext/commands/bot.py
+++ b/telegrampy/ext/commands/bot.py
@@ -115,7 +115,8 @@ class Bot(telegrampy.Client):
         self.cogs: Dict[str, Cog] = {}
         self.extensions: Dict[str, types.ModuleType] = {}
 
-        self._help_command: Optional[HelpCommand] = help_command
+        self._help_command: Optional[HelpCommand] = None
+        self.help_command = help_command
 
     @property
     def help_command(self) -> Optional[HelpCommand]:
@@ -125,7 +126,7 @@ class Bot(telegrampy.Client):
         return self._help_command
 
     @help_command.setter
-    def help_command(self, value: HelpCommand) -> None:
+    def help_command(self, value: Optional[HelpCommand]) -> None:
         if not isinstance(value, HelpCommand):
             raise TypeError("The new help command must inherit from HelpCommand.")
 
@@ -387,6 +388,7 @@ class Bot(telegrampy.Client):
         message: :class:`telegrampy.Message`
             The message to process.
         """
+
         if not message.content:
             return
 

--- a/telegrampy/ext/commands/cog.py
+++ b/telegrampy/ext/commands/cog.py
@@ -24,8 +24,8 @@ SOFTWARE.
 
 from __future__ import annotations
 
-import types
 import inspect
+import types
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, List, Optional, TypeVar
 
 from .core import Command
@@ -71,8 +71,7 @@ class CogMeta(type):
 
 
 class Cog(metaclass=CogMeta):
-    """
-    Base cog class.
+    """Base cog class.
 
     Attributes
     ----------
@@ -98,8 +97,7 @@ class Cog(metaclass=CogMeta):
 
     @classmethod
     def listener(cls, name: Optional[str] = None) -> Callable[[CoroFunc], CoroFunc]:
-        """
-        Makes a method in a cog a listener.
+        """Makes a method in a cog a listener.
 
         Parameters
         ----------

--- a/telegrampy/ext/commands/context.py
+++ b/telegrampy/ext/commands/context.py
@@ -27,14 +27,13 @@ from __future__ import annotations
 import io
 from typing import TYPE_CHECKING, Any, Coroutine, Dict, Generic, List, Optional, TypeVar, Union
 
-
 if TYPE_CHECKING:
+    from .bot import Bot
     from telegrampy.chat import Chat, ChatActionSender
     from telegrampy.message import Message
     from telegrampy.poll import Poll
     from telegrampy.user import User
     from telegrampy.utils import ParseMode
-    from .bot import Bot
     from .cog import Cog
     from .core import Command
 
@@ -43,7 +42,8 @@ if TYPE_CHECKING:
     ContextT = TypeVar("ContextT", bound="Context")
     CommandT = TypeVar("CommandT", bound="Command")
     CogT = TypeVar("CogT", bound="Cog")
-    BotT = TypeVar("BotT", bound="Bot")
+
+BotT = TypeVar("BotT", bound="Bot")
 
 
 class Context(Generic[BotT]):

--- a/telegrampy/ext/commands/context.py
+++ b/telegrampy/ext/commands/context.py
@@ -28,12 +28,12 @@ import io
 from typing import TYPE_CHECKING, Any, Coroutine, Dict, Generic, List, Optional, TypeVar, Union
 
 if TYPE_CHECKING:
-    from .bot import Bot
     from telegrampy.chat import Chat, ChatActionSender
     from telegrampy.message import Message
     from telegrampy.poll import Poll
     from telegrampy.user import User
     from telegrampy.utils import ParseMode
+    from .bot import Bot
     from .cog import Cog
     from .core import Command
 
@@ -47,8 +47,7 @@ BotT = TypeVar("BotT", bound="Bot")
 
 
 class Context(Generic[BotT]):
-    """
-    Context for a command.
+    """Context for a command.
 
     Attributes
     ----------
@@ -237,8 +236,7 @@ class Context(Generic[BotT]):
         await self.chat.send_action(action)
 
     def action(self, action: str) -> ChatActionSender:
-        """
-        Returns a context manager that sends a chat action, until the with statement is completed.
+        """Returns a context manager that sends a chat action, until the with statement is completed.
 
         Parameters
         ----------
@@ -249,8 +247,7 @@ class Context(Generic[BotT]):
         return self.chat.action(action)
 
     async def reply(self, content: str, parse_mode: Optional[ParseMode] = None) -> Message:
-        """
-        |coro|
+        """|coro|
 
         Replys to the message.
 

--- a/telegrampy/ext/commands/converter.py
+++ b/telegrampy/ext/commands/converter.py
@@ -22,17 +22,25 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from .errors import BadArgument
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Union
+
 from telegrampy.chat import Chat
-from telegrampy.user import User
 from telegrampy.errors import HTTPException, BadRequest
+from .errors import BadArgument
+
+if TYPE_CHECKING:
+    from telegrampy.user import User
+    from .context import Context
+
 
 class Converter:
     """
     Base class for converters.
     """
 
-    async def convert(self, ctx, arg):
+    async def convert(self, ctx: Context, arg: str) -> Any:
         """
         |coro|
 
@@ -40,12 +48,13 @@ class Converter:
         """
         raise NotImplementedError
 
+
 class UserConverter(Converter):
     """
     Converts an argument into a user.
     """
 
-    async def convert(self, ctx, arg):
+    async def convert(self, ctx: Context, arg: Union[str, Any]) -> User:
         try:
             arg = int(arg)
         except ValueError:
@@ -62,7 +71,7 @@ class ChatConverter(Converter):
     Converts an argument into a chat.
     """
 
-    async def convert(self, ctx, arg):
+    async def convert(self, ctx: Context, arg: Union[str, Any]) -> Chat:
         try:
             arg = int(arg)
         except ValueError:

--- a/telegrampy/ext/commands/converter.py
+++ b/telegrampy/ext/commands/converter.py
@@ -36,13 +36,10 @@ if TYPE_CHECKING:
 
 
 class Converter:
-    """
-    Base class for converters.
-    """
+    """Base class for converters."""
 
     async def convert(self, ctx: Context, arg: str) -> Any:
-        """
-        |coro|
+        """|coro|
 
         Does the converting.
         """
@@ -50,9 +47,7 @@ class Converter:
 
 
 class UserConverter(Converter):
-    """
-    Converts an argument into a user.
-    """
+    """Converts an argument into a user."""
 
     async def convert(self, ctx: Context, arg: Union[str, Any]) -> User:
         try:
@@ -66,10 +61,9 @@ class UserConverter(Converter):
         except HTTPException as exc:
             raise BadArgument(f"Error while fetching user '{arg}'") from exc
 
+
 class ChatConverter(Converter):
-    """
-    Converts an argument into a chat.
-    """
+    """Converts an argument into a chat."""
 
     async def convert(self, ctx: Context, arg: Union[str, Any]) -> Chat:
         try:

--- a/telegrampy/ext/commands/core.py
+++ b/telegrampy/ext/commands/core.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import inspect
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, Generic, List, Optional, TypeVar, Union
-from typing_extensions import ParamSpec, Concatenate
 
 import telegrampy
 from telegrampy import User, Chat
@@ -36,20 +35,26 @@ from .converter import *
 from .context import Context
 
 if TYPE_CHECKING:
+    from typing_extensions import ParamSpec, Concatenate
+
     from .bot import Bot
     from .cog import Cog
-
-    T = TypeVar("T")
-    Coro = Coroutine[Any, Any, T]
-    CoroFunc = Callable[..., Coro[Any]]
     ContextT = TypeVar("ContextT", bound="Context")
     CommandT = TypeVar("CommandT", bound="Command")
-    CogT = TypeVar("CogT", bound="Cog")
 
+T = TypeVar("T")
+Coro = Coroutine[Any, Any, T]
+CoroFunc = Callable[..., Coro[Any]]
+MaybeCoro = Union[T, Coro[T]]
+Check = Callable[[Context[Any]], MaybeCoro[bool]]
+
+CogT = TypeVar("CogT", bound="Cog")
+
+if TYPE_CHECKING:
     P = ParamSpec("P")
+else:
+    P = TypeVar("P")
 
-    MaybeCoro = Union[T, Coro[T]]
-    Check = Callable[[Context[Any]], MaybeCoro[bool]]
 
 class Command(Generic[CogT, P, T]):
     """

--- a/telegrampy/ext/commands/errors.py
+++ b/telegrampy/ext/commands/errors.py
@@ -22,7 +22,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from __future__ import annotations
+import inspect
+
+from typing import TYPE_CHECKING, Optional
+
 from telegrampy import TelegramException
+
+if TYPE_CHECKING:
+    from telegrampy.ext.commands.converter import Converter
 
 
 class CommandError(TelegramException):
@@ -62,7 +70,7 @@ class ExtensionAlreadyLoaded(ExtensionError):
     This inherits from :exc:`telegrampy.ext.commands.ExtensionError`.
     """
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
         super().__init__(f"Extension {name} is already loaded")
 
@@ -73,7 +81,7 @@ class ExtensionNotLoaded(ExtensionError):
     This inherits from :exc:`telegrampy.ext.commands.ExtensionError`.
     """
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
         super().__init__(f"Extension {name} has not been loaded")
 
@@ -84,7 +92,7 @@ class ExtensionNotFound(ExtensionError):
     This inherits from :exc:`telegrampy.ext.commands.ExtensionError`.
     """
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
         super().__init__(f"Extension {name} could not be loaded")
 
@@ -95,7 +103,7 @@ class NoEntryPointError(ExtensionError):
     This inherits from :exc:`telegrampy.ext.commands.ExtensionError`.
     """
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
         super().__init__(f"Extension {name} has no setup function")
 
@@ -113,7 +121,7 @@ class ExtensionFailed(ExtensionError):
         The original error that was raised.
     """
 
-    def __init__(self, name, original):
+    def __init__(self, name: str, original: Exception) -> None:
         self.name = name
         self.original = original
         super().__init__(f"Extension raised an exception: {original.__class__.__name__}: {original}")
@@ -135,11 +143,11 @@ class MissingRequiredArgument(UserInputError):
 
     Attributes
     ----------
-    param: :class:`str`
+    param: :class:`inspect.Parameter`
         The argument that is missing.
     """
 
-    def __init__(self, param):
+    def __init__(self, param: inspect.Parameter) -> None:
         self.param = param
         super().__init__(f"'{param}' is a required argument that is missing")
 
@@ -157,7 +165,7 @@ class ConversionError(CommandError):
         The original error that was failed.
     """
 
-    def __init__(self, converter, original):
+    def __init__(self, converter: Converter, original: Exception) -> None:
         self.converter = converter
         self.original = original
         super().__init__(f"Converter raised an exception: {original.__class__.__name__}: {original}")
@@ -194,7 +202,7 @@ class ExpectedClosingQuote(ArgumentParsingError):
     This inherits from :exc:`telegrampy.ext.commands.ArgumentParsingError`.
     """
 
-    def __init__(self, message=None):
+    def __init__(self, message: Optional[str] = None):
         super().__init__(message or "Expected a closing quote")
 
 class CheckFailure(CommandError):
@@ -211,7 +219,7 @@ class NotOwner(CheckFailure):
     This inherits from :exc:`telegrampy.ext.commands.CheckFailure`.
     """
 
-    def __init__(self, message=None):
+    def __init__(self, message: Optional[str] = None):
         super().__init__(message or "Only the owner can use this command")
 
 class PrivateChatOnly(CheckFailure):
@@ -221,7 +229,7 @@ class PrivateChatOnly(CheckFailure):
     This inherits from :exc:`telegrampy.ext.commands.CheckFailure`.
     """
 
-    def __init__(self, message=None):
+    def __init__(self, message: Optional[str] = None):
         super().__init__(message or "This command can only be used in private messages")
 
 class GroupOnly(CheckFailure):
@@ -231,7 +239,7 @@ class GroupOnly(CheckFailure):
     This inherits from :exc:`telegrampy.ext.commands.CheckFailure`.
     """
 
-    def __init__(self, message=None):
+    def __init__(self, message: Optional[str] = None):
         super().__init__(message or "This command can only be used in groups")
 
     pass
@@ -248,6 +256,6 @@ class CommandInvokeError(CommandError):
         The original error that was raised.
     """
 
-    def __init__(self, original):
+    def __init__(self, original: Exception) -> None:
         self.original = original
         super().__init__(f"Command raised an exception: {original.__class__.__name__}: {original}")

--- a/telegrampy/ext/commands/errors.py
+++ b/telegrampy/ext/commands/errors.py
@@ -23,49 +23,46 @@ SOFTWARE.
 """
 
 from __future__ import annotations
-import inspect
 
+import inspect
 from typing import TYPE_CHECKING, Optional
 
 from telegrampy import TelegramException
 
 if TYPE_CHECKING:
-    from telegrampy.ext.commands.converter import Converter
+    from .converter import Converter
 
 
 class CommandError(TelegramException):
-    """
-    Base exception for all command errors.
+    """Base exception for all command errors.
 
     This inherits from :exc:`telegrampy.TelegramException`.
     """
 
+
 class CommandNotFound(CommandError):
-    """
-    Raised when a command is not found.
+    """Raised when a command is not found.
 
     This inherits from :exc:`telegrampy.ext.commands.CommandError`.
     """
+
 
 class CommandRegistrationError(CommandError):
-    """
-    Raised when a command cannot be registered.
+    """Raised when a command cannot be registered.
 
     This inherits from :exc:`telegrampy.ext.commands.CommandError`.
     """
 
-    pass
 
 class ExtensionError(CommandError):
-    """
-    Base exception for extension related errors.
+    """Base exception for extension related errors.
 
     This inherits from :exc:`telegrampy.ext.commands.CommandError`.
     """
 
+
 class ExtensionAlreadyLoaded(ExtensionError):
-    """
-    Raised when an extension is already loaded.
+    """Raised when an extension is already loaded.
 
     This inherits from :exc:`telegrampy.ext.commands.ExtensionError`.
     """
@@ -74,9 +71,9 @@ class ExtensionAlreadyLoaded(ExtensionError):
         self.name = name
         super().__init__(f"Extension {name} is already loaded")
 
+
 class ExtensionNotLoaded(ExtensionError):
-    """
-    Raised when an extension is not loaded.
+    """Raised when an extension is not loaded.
 
     This inherits from :exc:`telegrampy.ext.commands.ExtensionError`.
     """
@@ -85,9 +82,9 @@ class ExtensionNotLoaded(ExtensionError):
         self.name = name
         super().__init__(f"Extension {name} has not been loaded")
 
+
 class ExtensionNotFound(ExtensionError):
-    """
-    Raised when an extension is not found.
+    """Raised when an extension is not found.
 
     This inherits from :exc:`telegrampy.ext.commands.ExtensionError`.
     """
@@ -96,9 +93,9 @@ class ExtensionNotFound(ExtensionError):
         self.name = name
         super().__init__(f"Extension {name} could not be loaded")
 
+
 class NoEntryPointError(ExtensionError):
-    """
-    Raised when an extension has no `setup` function.
+    """Raised when an extension has no `setup` function.
 
     This inherits from :exc:`telegrampy.ext.commands.ExtensionError`.
     """
@@ -107,9 +104,9 @@ class NoEntryPointError(ExtensionError):
         self.name = name
         super().__init__(f"Extension {name} has no setup function")
 
+
 class ExtensionFailed(ExtensionError):
-    """
-    Raised when an extension fails.
+    """Raised when an extension fails.
 
     This inherits from :exc:`telegrampy.ext.commands.ExtensionError`.
 
@@ -126,18 +123,16 @@ class ExtensionFailed(ExtensionError):
         self.original = original
         super().__init__(f"Extension raised an exception: {original.__class__.__name__}: {original}")
 
+
 class UserInputError(CommandError):
-    """
-    Base exception for errors that involve user input.
+    """Base exception for errors that involve user input.
 
     This inherits from :exc:`telegrampy.ext.commands.CommandError`.
     """
 
-    pass
 
 class MissingRequiredArgument(UserInputError):
-    """
-    Raised when a required argument is missing.
+    """Raised when a required argument is missing.
 
     This inherits from :exc:`telegrampy.ext.commands.UserInputError`.
 
@@ -151,9 +146,9 @@ class MissingRequiredArgument(UserInputError):
         self.param = param
         super().__init__(f"'{param}' is a required argument that is missing")
 
+
 class ConversionError(CommandError):
-    """
-    Raised when a :class:`telegrampy.ext.commands.Converter` fails.
+    """Raised when a :class:`telegrampy.ext.commands.Converter` fails.
 
     This inherits from :exc:telegrampy.ext.commands.UserInputError`.
 
@@ -170,9 +165,9 @@ class ConversionError(CommandError):
         self.original = original
         super().__init__(f"Converter raised an exception: {original.__class__.__name__}: {original}")
 
+
 class BadArgument(UserInputError):
-    """
-    Raised when a bad argument is given.
+    """Raised when a bad argument is given.
 
     This inherits from :exc:`telegrampy.ext.commands.UserInputError`.
 
@@ -184,20 +179,16 @@ class BadArgument(UserInputError):
         The name of the converter that failed.
     """
 
-    pass
 
 class ArgumentParsingError(UserInputError):
-    """
-    Base exception for argument parsing errors.
+    """Base exception for argument parsing errors.
 
     This inherits from :exc:`telegrampy.ext.commands.UserInputError`.
     """
 
-    pass
 
 class ExpectedClosingQuote(ArgumentParsingError):
-    """
-    Raised when the argument parser expects a closing quote but can't find one.
+    """Raised when the argument parser expects a closing quote but can't find one.
 
     This inherits from :exc:`telegrampy.ext.commands.ArgumentParsingError`.
     """
@@ -205,16 +196,16 @@ class ExpectedClosingQuote(ArgumentParsingError):
     def __init__(self, message: Optional[str] = None):
         super().__init__(message or "Expected a closing quote")
 
+
 class CheckFailure(CommandError):
-    """
-    Raised when a check fails.
+    """Raised when a check fails.
 
     This inherits from :exc:`telegrampy.ext.commands.CheckFailure`.
     """
 
+
 class NotOwner(CheckFailure):
-    """
-    Raised when a user is not the owner of the bot.
+    """Raised when a user is not the owner of the bot.
 
     This inherits from :exc:`telegrampy.ext.commands.CheckFailure`.
     """
@@ -222,9 +213,9 @@ class NotOwner(CheckFailure):
     def __init__(self, message: Optional[str] = None):
         super().__init__(message or "Only the owner can use this command")
 
+
 class PrivateChatOnly(CheckFailure):
-    """
-    Raised when a command can only be used in private chats.
+    """Raised when a command can only be used in private chats.
 
     This inherits from :exc:`telegrampy.ext.commands.CheckFailure`.
     """
@@ -232,9 +223,9 @@ class PrivateChatOnly(CheckFailure):
     def __init__(self, message: Optional[str] = None):
         super().__init__(message or "This command can only be used in private messages")
 
+
 class GroupOnly(CheckFailure):
-    """
-    Raised when a command can only be used in groups.
+    """Raised when a command can only be used in groups.
 
     This inherits from :exc:`telegrampy.ext.commands.CheckFailure`.
     """
@@ -242,11 +233,9 @@ class GroupOnly(CheckFailure):
     def __init__(self, message: Optional[str] = None):
         super().__init__(message or "This command can only be used in groups")
 
-    pass
 
 class CommandInvokeError(CommandError):
-    """
-    Raised when a command fails.
+    """Raised when a command fails.
 
     This inherits from :exc:`telegrampy.ext.commands.CommandError`.
 

--- a/telegrampy/ext/commands/help.py
+++ b/telegrampy/ext/commands/help.py
@@ -26,16 +26,14 @@ from __future__ import annotations
 
 import html
 import itertools
-from typing import TYPE_CHECKING, Any, Dict, List, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar
 
-import telegrampy
-from .errors import *
-from .core import Command
 from .cog import Cog
+from .core import Command
+from .errors import CommandError
 
 if TYPE_CHECKING:
     from .bot import Bot
-    from .core import Command
 
     CommandT = TypeVar("CommandT", bound="Command")
 
@@ -48,6 +46,7 @@ class _HelpCommandImplementation(Command):
 
         super().__init__(help_cmd, **command_attrs)
         self.bot: Bot = bot
+
 
 class HelpCommand:
     """Help command template.
@@ -81,8 +80,7 @@ class HelpCommand:
         self._implementation = None
 
     async def get_command_signature(self, command: Command) -> str:
-        """
-        |coro|
+        """|coro|
 
         The method that gets a formatted command signature
 
@@ -94,8 +92,7 @@ class HelpCommand:
         return f"/{name} {sig}"
 
     async def send_bot_help(self) -> None:
-        """
-        |coro|
+        """|coro|
 
         The method that sends help for the bot.
 
@@ -105,8 +102,7 @@ class HelpCommand:
         raise NotImplementedError("Subclasses must implement this.")
 
     async def send_cog_help(self, cog: Cog) -> None:
-        """
-        |coro|
+        """|coro|
 
         The method that sends help for a cog.
 
@@ -134,8 +130,7 @@ class HelpCommand:
         raise NotImplementedError("Subclasses must implement this.")
 
     async def send_not_found(self, query: str) -> None:
-        """
-        |coro|
+        """|coro|
 
         The method that sends a 'not found' message or similar.
 
@@ -149,8 +144,7 @@ class HelpCommand:
         await self.ctx.send(f"A command or cog named '{query}' was not found.")
 
     async def help_callback(self, query: Optional[str]) -> None:
-        """
-        |coro|
+        """|coro|
 
         The callback that searches for a matching commmand or cog.
 
@@ -267,8 +261,7 @@ class DefaultHelpCommand(HelpCommand):
         return formatted
 
     async def format_command(self, command: Command) -> List[str]:
-        """
-        |coro|
+        """|coro|
 
         The method that formats an individual command.
 
@@ -288,8 +281,7 @@ class DefaultHelpCommand(HelpCommand):
         return help_text
 
     async def filter_commands(self, commands: List[CommandT]) -> List[CommandT]:
-        """
-        |coro|
+        """|coro|
 
         Takes a list of commands and filters them.
 
@@ -359,8 +351,6 @@ class DefaultHelpCommand(HelpCommand):
         await self.send_help_text(help_text)
 
     async def send_cog_help(self, cog: Cog) -> None:
-        bot = self.bot
-
         help_text = []
 
         if cog.description:

--- a/telegrampy/ext/commands/help.py
+++ b/telegrampy/ext/commands/help.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import html
 import itertools
-from sys import implementation
 from typing import TYPE_CHECKING, Any, Dict, List, TypeVar
 
 import telegrampy

--- a/telegrampy/http.py
+++ b/telegrampy/http.py
@@ -22,12 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from __future__ import annotations
+
 import asyncio
-import datetime
-import json
 import io
+import json
 import logging
 import sys
+from typing import Any, TYPE_CHECKING, List, Literal, Sequence, TypeVar, Coroutine, Optional, Dict
 
 import aiohttp
 
@@ -36,7 +38,12 @@ from .errors import *
 from .user import User
 from .chat import Chat
 from .message import Message
-from .poll import *
+from .poll import Poll
+
+if TYPE_CHECKING:
+    T = TypeVar("T")
+    Response = Coroutine[Any, Any, T]
+    HTTPMethod = Literal["GET", "POST", "HEAD", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE"]
 
 log = logging.getLogger("telegrampy.http")
 
@@ -46,28 +53,32 @@ user_agent = "TelegramBot (https://github.com/ilovetocode2019/telegram.py {0}) P
 class Route:
     """Represents a Telegram route"""
 
-    BASE_URL = ""
+    BASE_URL: str = "https://api.telegram.org/bot{0}/"
 
-    def __init__(self, method, url):
-        self.method = method
-        self.url = url
+    if TYPE_CHECKING:
+        method: HTTPMethod
+        url: str
 
-    def __str__(self):
+    def __init__(self, method: HTTPMethod, url: str):
+        self.method: HTTPMethod = method
+        self.url: str = url
+
+    def __str__(self) -> str:
         return f"{self.method}: {self.url}"
 
 
 class HTTPClient:
     """Represents an HTTP client making requests to Telegram."""
 
-    def __init__(self, token: str, loop: asyncio.BaseEventLoop):
-        self._token = token
-        self._base_url = f"https://api.telegram.org/bot{self._token}/"
+    def __init__(self, token: str, loop: asyncio.AbstractEventLoop):
+        self._token: str = token
+        self._base_url: str = Route.BASE_URL.format(self._token)
 
-        self.loop = loop or asyncio.get_event_loop()
-        self.user_agent = user_agent.format(__version__, sys.version_info, aiohttp.__version__)
-        self.session = aiohttp.ClientSession(loop=self.loop, headers={"User-Agent": self.user_agent})
+        self.loop: asyncio.AbstractEventLoop = loop or asyncio.get_event_loop()
+        self.user_agent: str = user_agent.format(__version__, sys.version_info, aiohttp.__version__)
+        self.session: aiohttp.ClientSession = aiohttp.ClientSession(loop=self.loop, headers={"User-Agent": self.user_agent})
 
-    async def request(self, route: Route, **kwargs):
+    async def request(self, route: Route, **kwargs: Any) -> Any:
         """Make a request to a route.
 
         All kwargs will be forwarded to
@@ -81,64 +92,80 @@ class HTTPClient:
         url = route.url
         method = route.method
 
+        resp: Optional[aiohttp.ClientResponse] = None
+        data: Optional[Dict[str, Any]] = None
+
         # Try a request 5 times before dropping it
         for tries in range(5):
             log.debug(f"Requesting to {method}:{url} (Attempt {tries+1})")
 
-            async with self.session.request(method, url, timeout=30, **kwargs) as resp:
-                # Telegram docs say all responses will have json
-                data = await resp.json()
+            try:
+                async with self.session.request(method, url, timeout=30, **kwargs) as resp:
+                    # Telegram docs say all responses will have json
+                    data = await resp.json()
 
-                if 300 > resp.status >= 200:
-                    return data
+                    if not isinstance(data, dict):
+                        raise RuntimeError("Response from Telegram is not in JSON format.")
 
-                # We are getting ratelimited
-                if resp.status == 429:
-                    params = data.get("parameters")
+                    if 300 > resp.status >= 200:
+                        return data
 
-                    if not params:
-                        raise HTTPException(resp, data.get("description"))
+                    # We are getting ratelimited
+                    if resp.status == 429:
+                        params = data.get("parameters")
 
-                    retry_after = params.get("retry_after")
+                        if not params:
+                            raise HTTPException(resp, data.get("description"))
 
-                    # We didn't get a retry after, so raise an HTTPException
-                    if not retry_after:
-                        raise HTTPException(resp, data.get("description"))
+                        retry_after = params.get("retry_after")
 
-                    log.warning(f"We are being ratelimited. Retrying in {retry_after} seconds.")
+                        # We didn't get a retry after, so raise an HTTPException
+                        if not retry_after:
+                            raise HTTPException(resp, data.get("description"))
 
-                    await asyncio.sleep(retry_after)
-                    continue
+                        log.warning(f"We are being ratelimited. Retrying in {retry_after} seconds.")
 
-                # Unauthorized
-                if resp.status == 400:
-                    raise BadRequest(resp, data.get("description"))
-                elif resp.status == 401:
-                    raise InvalidToken(resp, data.get("description"))
-                # Forbidden
-                elif resp.status == 403:
-                    raise Forbidden(resp, data.get("description"))
-                # Not found
-                if resp.status == 404:
-                    raise InvalidToken(resp, data.get("description"))
-                # Conflict with other request
-                elif resp.status == 409:
-                    raise Conflict(resp, data.get("description"))
-                # Some sort of internal Telegram error
-                if resp.status >= 500:
+                        await asyncio.sleep(retry_after)
+                        continue
+
+                    # Unauthorized
+                    if resp.status == 400:
+                        raise BadRequest(resp, data.get("description"))
+                    elif resp.status == 401:
+                        raise InvalidToken(resp, data.get("description"))
+                    # Forbidden
+                    elif resp.status == 403:
+                        raise Forbidden(resp, data.get("description"))
+                    # Not found
+                    if resp.status == 404:
+                        raise InvalidToken(resp, data.get("description"))
+                    # Conflict with other request
+                    elif resp.status == 409:
+                        raise Conflict(resp, data.get("description"))
+                    # Some sort of internal Telegram error
+                    if resp.status >= 500:
+                        await asyncio.sleep((1 + tries) * 2)
+                        continue
+                    else:
+                        raise HTTPException(resp, (data).get("description"))
+            except OSError as e:
+                # Connection reset by peer
+                if tries < 4 and e.errno in (54, 10054):
                     await asyncio.sleep((1 + tries) * 2)
                     continue
-                else:
-                    raise HTTPException(resp, (data).get("description"))
+                raise
 
-        log.debug(f"Request to to {method}:{url} failed with status code {resp.status}")
+        if resp is not None:
+            log.debug(f"Request to to {method}:{url} failed with status code {resp.status}")
 
-        if resp.status >= 500:
-            raise ServerError(resp, data.get("description"))
-        else:
-            raise HTTPException(resp, data.get("description"))
+            description = data.get("description") if isinstance(data, dict) else data
 
-    async def send_message(self, chat_id: int, content: str, parse_mode: str = None, reply_message_id: int = None):
+            if resp.status >= 500:
+                raise ServerError(resp, description)
+            else:
+                raise HTTPException(resp, description)
+
+    async def send_message(self, chat_id: int, content: str, parse_mode: str = None, reply_message_id: int = None) -> Message:
         """Sends a message to a chat."""
 
         url = self._base_url + "sendMessage"
@@ -151,11 +178,10 @@ class HTTPClient:
 
         response = await self.request(Route("POST", url), json=data)
 
-        if "result" in response:
-            message = Message(self, response["result"])
-            return message
+        message = Message(self, response["result"])
+        return message
 
-    async def edit_message_content(self, chat_id: int, message_id: int, content: str, parse_mode: str = None):
+    async def edit_message_content(self, chat_id: int, message_id: int, content: str, parse_mode: str = None) -> Optional[Message]:
         """Edits a message."""
 
         url = self._base_url + "editMessageText"
@@ -169,29 +195,27 @@ class HTTPClient:
         if response is True:
             return
 
-        if "result" in response:
-            edited_message = Message(self, response["result"])
-            return edited_message
+        edited_message = Message(self, response["result"])
+        return edited_message
 
-    async def delete_message(self, chat_id: int, message_id: int):
+    async def delete_message(self, chat_id: int, message_id: int) -> None:
         """Deletes a message."""
 
         url = self._base_url + "deleteMessage"
         data = {"chat_id": chat_id, "message_id": message_id}
         await self.request(Route("POST", url), json=data)
 
-    async def forward_message(self, chat_id: int, from_chat_id: int, message_id: int):
+    async def forward_message(self, chat_id: int, from_chat_id: int, message_id: int) -> Message:
         """Forwards a message."""
 
         url = self._base_url + "forwardMessage"
         data = {"chat_id": chat_id, "from_chat_id": from_chat_id, "message_id": message_id}
         response = await self.request(Route("POST", url), json=data)
 
-        if "result" in response:
-            forwarded_message = Message(self, response["result"])
-            return forwarded_message
+        forwarded_message = Message(self, response["result"])
+        return forwarded_message
 
-    async def send_photo(self, chat_id: int, file: io.BytesIO, filename: str = None, caption: str = None, parse_mode: str = None):
+    async def send_photo(self, chat_id: int, file: io.BytesIO, filename: str = None, caption: str = None, parse_mode: str = None) -> Message:
         """Sends a photo to a chat."""
 
         url = self._base_url + "sendPhoto"
@@ -206,11 +230,10 @@ class HTTPClient:
 
         response = await self.request(Route("POST", url), data=writer)
 
-        if "result" in response:
-            message = Message(self, response["result"])
-            return message
+        message = Message(self, response["result"])
+        return message
 
-    async def send_document(self, chat_id: int, file: io.BytesIO, filename: str = None, caption: str = None, parse_mode: str = None):
+    async def send_document(self, chat_id: int, file: io.BytesIO, filename: str = None, caption: str = None, parse_mode: str = None) -> Message:
         """Sends a document to a chat."""
 
         url = self._base_url + "sendDocument"
@@ -225,68 +248,68 @@ class HTTPClient:
 
         response = await self.request(Route("POST", url), data=writer)
 
-        if "result" in response:
-            message = Message(self, response["result"])
-            return message
+        message = Message(self, response["result"])
+        return message
 
-    async def send_poll(self, chat_id: int, question: str, options: list):
+    async def send_poll(self, chat_id: int, question: str, options: List[str]) -> Poll:
         """Sends a poll to a chat."""
 
         url = self._base_url + "sendPoll"
         data = {"chat_id": chat_id, "question": question, "options": json.dumps(options)}
         response = await self.request(Route("POST", url), json=data)
 
-        if "result" in response:
-            message = Poll(self, response["result"])
-            return message
+        message = Poll(self, response["result"])
+        return message
 
-    async def send_chat_action(self, chat_id: int, action: str):
+    async def send_chat_action(self, chat_id: int, action: str) -> None:
         """Sends a chat action to a chat."""
 
         url = self._base_url + "sendChatAction"
         data = {"chat_id": chat_id, "action": action}
         await self.request(Route("POST", url), json=data)
 
-    async def get_chat(self, chat_id: int):
+    async def get_chat(self, chat_id: int) -> Chat:
         """Fetches a chat."""
 
         url = self._base_url + "getChat"
         data = {"chat_id": chat_id}
         response = await self.request(Route("GET", url), json=data)
 
-        if "result" in response:
-            return Chat(self, response["result"])
+        return Chat(self, response["result"])
 
-    async def get_chat_member(self, chat_id: int, user_id: int):
+    async def get_chat_member(self, chat_id: int, user_id: int) -> User:
         """Fetches a member from a chat."""
 
         url = self._base_url + "getChatMember"
         data = {"chat_id": chat_id, "user_id": user_id}
         response = await self.request(Route("GET", url), json=data)
 
-        if "result" in response:
-            return User(self, response["result"].get("user"))
+        return User(self, response["result"].get("user"))
 
-    async def get_me(self):
+    async def get_me(self) -> User:
         """Fetches the bot account."""
 
         url = self._base_url + "getMe"
         response = await self.request(Route("GET", url))
 
-        if "result" in response:
-            return User(self, response["result"])
+        return User(self, response["result"])
 
-    async def get_updates(self, offset=None, limit=100, timeout=0, allowed_updates=None):
+    async def get_updates(
+        self,
+        offset: int = None,
+        limit: int = 100,
+        timeout: int = 0,
+        allowed_updates: Sequence[str] = None
+    ) -> List[Dict[str, Any]]:
         """Fetches the new updates for the bot."""
 
         url = self._base_url + "getUpdates"
         data = {"offset": offset, "limit": limit, "timeout": timeout, "allowed_updates": allowed_updates}
         response = await self.request(Route("POST", url), json=data)
 
-        if "result" in response:
-            return response["result"]
+        return response["result"]
 
-    async def close(self):
+    async def close(self) -> None:
         """Closes the HTTP session."""
 
         await self.session.close()

--- a/telegrampy/http.py
+++ b/telegrampy/http.py
@@ -45,9 +45,9 @@ if TYPE_CHECKING:
     Response = Coroutine[Any, Any, T]
     HTTPMethod = Literal["GET", "POST", "HEAD", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE"]
 
-log = logging.getLogger("telegrampy.http")
+log: logging.Logger = logging.getLogger("telegrampy.http")
 
-user_agent = "TelegramBot (https://github.com/ilovetocode2019/telegram.py {0}) Python/{1[0]}.{1[1]} aiohttp/{2}"
+user_agent: str = "TelegramBot (https://github.com/ilovetocode2019/telegram.py {0}) Python/{1[0]}.{1[1]} aiohttp/{2}"
 
 
 class Route:

--- a/telegrampy/message.py
+++ b/telegrampy/message.py
@@ -25,13 +25,13 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Optional
 
-from .chat import Chat
 from .user import User
 from .abc import TelegramObject
 
 if TYPE_CHECKING:
+    from .chat import Chat
     from .http import HTTPClient
     from .utils import ParseMode
     from .types.message import Message as MessagePayload

--- a/telegrampy/message.py
+++ b/telegrampy/message.py
@@ -29,8 +29,8 @@ from typing import TYPE_CHECKING, Optional
 
 from .abc import TelegramObject
 from .chat import Chat
-from .user import User
 from .mixins import Hashable
+from .user import User
 
 if TYPE_CHECKING:
     from .http import HTTPClient
@@ -39,8 +39,7 @@ if TYPE_CHECKING:
 
 
 class Message(TelegramObject, Hashable):
-    """
-    Represents a message in Telegram.
+    """Represents a message in Telegram.
 
     .. container:: operations
 

--- a/telegrampy/message.py
+++ b/telegrampy/message.py
@@ -27,17 +27,18 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Optional
 
-from .user import User
 from .abc import TelegramObject
+from .chat import Chat
+from .user import User
+from .mixins import Hashable
 
 if TYPE_CHECKING:
-    from .chat import Chat
     from .http import HTTPClient
     from .utils import ParseMode
     from .types.message import Message as MessagePayload
 
 
-class Message(TelegramObject):
+class Message(TelegramObject, Hashable):
     """
     Represents a message in Telegram.
 
@@ -76,7 +77,7 @@ class Message(TelegramObject):
         author: Optional[User]
 
     def __init__(self, http: HTTPClient, data: MessagePayload):
-        super().__init__(http, data)
+        super().__init__(http)
         self.id: int = data.get("message_id")
 
         created_at: int = data.get("date")

--- a/telegrampy/mixins.py
+++ b/telegrampy/mixins.py
@@ -1,7 +1,7 @@
 """
 MIT License
 
-Copyright (c) 2020 ilovetocode
+Copyright (c) 2020-2021 ilovetocode
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,41 +24,21 @@ SOFTWARE.
 
 from __future__ import annotations
 
-import re
-from typing import Literal
 
-Version = Literal[1, 2]
-ParseMode = Literal["HTML", "Markdown", "MarkdownV2"]
+class EqualityComparable:
+
+    id: int
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, self.__class__) and self.id == other.id
+
+    def __ne__(self, other: object) -> bool:
+        if isinstance(other, self.__class__):
+            return other.id != self.id
+        return True
 
 
-def escape_markdown(text: str, *, version: Version = 2) -> str:
-    """Tool that escapes markdown from a given string.
+class Hashable(EqualityComparable):
 
-    Parameters
-    ----------
-    text: :class:`str`
-        The text to escape markdown from.
-    version: Optional[:class:`int`]
-        The Telegram markdown version to use. Only 1 and 2 are supported.
-
-    Returns
-    -------
-    :class:`str`
-        The escaped text.
-
-    Raises
-    ------
-    :exc:`ValueError`
-        An unsupported version was provided.
-    """
-
-    if version == 1:
-        characters = r"_*`["
-
-    elif version == 2:
-        characters = r"_*[]()~`>#+-=|{}.!"
-
-    else:
-        raise ValueError(f"Version '{version}' unsupported. Only version 1 and 2 are supported.")
-
-    return re.sub(f"([{re.escape(characters)}])", r"\\\1", text)
+    def __hash__(self) -> int:
+        return self.id

--- a/telegrampy/poll.py
+++ b/telegrampy/poll.py
@@ -24,10 +24,10 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
-from .user import User
 from .abc import TelegramObject
+from .user import User
 
 if TYPE_CHECKING:
     from .http import HTTPClient

--- a/telegrampy/poll.py
+++ b/telegrampy/poll.py
@@ -85,7 +85,7 @@ class Poll(TelegramObject):
         allows_multiple_answers: bool
 
     def __init__(self, http: HTTPClient, data: PollPayload) -> None:
-        super().__init__(http, data)
+        super().__init__(http)
         self.question: str = data.get("question")
         self.options: List[PollOptionPayload] = data.get("options")
         self.total_voter_count: int = data.get("total_voter_count")

--- a/telegrampy/poll.py
+++ b/telegrampy/poll.py
@@ -22,8 +22,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from __future__ import annotations
+
+from typing import List, TYPE_CHECKING
+
 from .user import User
 from .abc import TelegramObject
+
+if TYPE_CHECKING:
+    from .http import HTTPClient
+    from .types.poll import (
+        PollOption as PollOptionPayload,
+        Poll as PollPayload,
+        PollAnswer as PollAnswerPayload
+    )
+
 
 class Poll(TelegramObject):
     """A Telegram poll.
@@ -62,18 +75,28 @@ class Poll(TelegramObject):
         If the poll allows multiple answers.
     """
 
-    def __init__(self, http, data):
-        super().__init__(http, data)
-        self.question = data.get("question")
-        self.options = data.get("options")
-        self.total_voter_count = data.get("total_voter_count")
-        self.is_closed = data.get("is_closed")
-        self.is_anonymous = data.get("is_anoymous")
-        self.type = data.get("type")
-        self.allow_multiple_answers = data.get("allow_multiple_answers")
+    if TYPE_CHECKING:
+        question: str
+        options: List[PollOptionPayload]
+        total_voter_count: int
+        is_closed: bool
+        is_anonymous: bool
+        type: str
+        allows_multiple_answers: bool
 
-    def __str__(self):
+    def __init__(self, http: HTTPClient, data: PollPayload) -> None:
+        super().__init__(http, data)
+        self.question: str = data.get("question")
+        self.options: List[PollOptionPayload] = data.get("options")
+        self.total_voter_count: int = data.get("total_voter_count")
+        self.is_closed: bool = data.get("is_closed")
+        self.is_anonymous: bool = data.get("is_anonymous")
+        self.type: str = data.get("type")
+        self.allows_multiple_answers: bool = data.get("allows_multiple_answers")
+
+    def __str__(self) -> str:
         return self.question
+
 
 class PollAnswer:
     """An answer to a non-anonymous poll.
@@ -86,12 +109,16 @@ class PollAnswer:
         The user that answered the poll.
     option_ids: List[:class:`int`]
         The options that the user selected.
-
     """
 
-    def __init__(self, data):
+    if TYPE_CHECKING:
+        id: str
+        user: User
+        option_ids: List[int]
+
+    def __init__(self, http: HTTPClient, data: PollAnswerPayload) -> None:
         self._data = data
 
-        self.poll_id = data.get("poll_id")
-        self.user = User(data.get("user"))
-        self.option_ids = data.get("option_ids")
+        self.id: str = data.get("poll_id")
+        self.user: User = User(http, data.get("user"))
+        self.option_ids: List[int] = data.get("option_ids")

--- a/telegrampy/types/chat.py
+++ b/telegrampy/types/chat.py
@@ -5,7 +5,7 @@ Copyright (c) 2020-2021 ilovetocode
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
+in the Software without reOptional[str]iction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
@@ -22,11 +22,54 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, Literal, Optional, TypedDict
+
+if TYPE_CHECKING:
+    from .message import Message, Location
+
+
+class ChatPhoto(TypedDict):
+    small_file_id: str
+    small_file_unique_id: str
+    big_file_id: str
+    big_fild_unique_id: str
+
+
+class ChatPermissions(TypedDict):
+    can_send_messages: Optional[bool]
+    can_send_media_messages: Optional[bool]
+    can_send_polls: Optional[bool]
+    can_send_other_messages: Optional[bool]
+    can_add_web_page_previews: Optional[bool]
+    can_change_info: Optional[bool]
+    can_invite_users: Optional[bool]
+    can_pin_messages: Optional[bool]
+    can_send_other_messages: Optional[bool]
+
+
+class ChatLocation(TypedDict):
+    location: Location
+    address: str
 
 
 class Chat(TypedDict):
-    title: str
-    username: str
-    description: str
-    type: int
+    id: int
+    type: str
+    title: Optional[str]
+    username: Optional[str]
+    first_name: Optional[str]
+    last_name: Optional[str]
+    photo: Optional[ChatPhoto]
+    bio: Optional[str]
+    has_private_forwards: Optional[Literal[True]]
+    description: Optional[str]
+    invite_link: Optional[str]
+    pinned_message: Optional[Message]
+    permissions: Optional[ChatPermissions]
+    slow_mode_delay: Optional[int]
+    message_auto_delete_time: Optional[int]
+    has_protected_content: Optional[Literal[True]]
+    sticker_set_name: Optional[str]
+    can_set_sticker_set: Optional[Literal[True]]
+    linked_chat_id: Optional[int]
+    location: Optional[ChatLocation]

--- a/telegrampy/types/chat.py
+++ b/telegrampy/types/chat.py
@@ -1,7 +1,7 @@
 """
 MIT License
 
-Copyright (c) 2020 ilovetocode
+Copyright (c) 2020-2021 ilovetocode
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,43 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from __future__ import annotations
-
-import re
-from typing import Literal
-
-Version = Literal[1, 2]
-ParseMode = Literal["HTML", "Markdown", "MarkdownV2"]
+from typing import TypedDict
 
 
-def escape_markdown(text: str, *, version: Version = 2) -> str:
-    """Tool that escapes markdown from a given string.
-
-    Parameters
-    ----------
-    text: :class:`str`
-        The text to escape markdown from.
-    version: Optional[:class:`int`]
-        The Telegram markdown version to use. Only 1 and 2 are supported.
-
-    Returns
-    -------
-    :class:`str`
-        The escaped text.
-
-    Raises
-    ------
-    :exc:`ValueError`
-        An unsupported version was provided.
-    """
-
-    if version == 1:
-        characters = r"_*`["
-
-    elif version == 2:
-        characters = r"_*[]()~`>#+-=|{}.!"
-
-    else:
-        raise ValueError(f"Version '{version}' unsupported. Only version 1 and 2 are supported.")
-
-    return re.sub(f"([{re.escape(characters)}])", r"\\\1", text)
+class Chat(TypedDict):
+    title: str
+    username: str
+    description: str
+    type: int

--- a/telegrampy/types/message.py
+++ b/telegrampy/types/message.py
@@ -24,11 +24,12 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, List, Literal, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, List, Literal, Optional, TypedDict
 
-from .chat import Chat
-from .poll import Poll
-from .user import User
+if TYPE_CHECKING:
+    from .chat import Chat
+    from .poll import Poll
+    from .user import User
 
 
 class MessageEntity(TypedDict):

--- a/telegrampy/types/message.py
+++ b/telegrampy/types/message.py
@@ -1,0 +1,211 @@
+"""
+MIT License
+
+Copyright (c) 2020-2021 ilovetocode
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Literal, Optional, TypedDict
+
+from .chat import Chat
+from .poll import Poll
+from .user import User
+
+
+class MessageEntity(TypedDict):
+    type: str
+    offset: int
+    length: int
+    url: str
+    user: User
+    language: str
+
+
+class _BaseFile(TypedDict):
+    file_id: str
+    file_unique_id: str
+    file_size: Optional[int]
+
+class PhotoSize(_BaseFile):
+    width: int
+    height: int
+
+
+class _File(_BaseFile):
+    thumb: Optional[PhotoSize]
+    file_name: Optional[str]
+    mime_type: Optional[str]
+
+
+class Animation(_File):
+    duration: int
+    width: int
+    height: int
+
+
+class Audio(_File):
+    duration: int
+    performer: Optional[str]
+    title: Optional[str]
+
+
+Document = _File
+Video = Animation
+
+
+class VideoNote(_BaseFile):
+    length: int
+    duration: int
+    thumb: Optional[PhotoSize]
+
+
+class Voice(_BaseFile):
+    duration: int
+    thumb: Optional[PhotoSize]
+    mime_type: Optional[str]
+
+
+class Contact(TypedDict):
+    phone_number: str
+    first_name: str
+    last_name: Optional[str]
+    user_id: Optional[int]
+    vcard: Optional[str]
+
+
+class Dice(TypedDict):
+    emoji: str
+    value: int
+
+
+class Location(TypedDict):
+    longitude: float
+    latitude: float
+    horizontal_accuracy: Optional[float]
+    live_period: Optional[int]
+    heading: Optional[int]
+    proximity_alert_radius: Optional[int]
+
+
+class Venue(TypedDict):
+    location: Location
+    title: str
+    address: str
+    foursquare_id: Optional[str]
+    foursquare_type: Optional[str]
+    google_place_id: Optional[str]
+    google_place_type: Optional[str]
+
+
+class ProximityAlertTriggered(TypedDict):
+    traveler: User
+    watcher: User
+    distance: int
+
+
+class MessageAutoDeleteTimerChanged(TypedDict):
+    message_auto_delete_time: int
+
+
+class VoiceChatScheduled(TypedDict):
+    start_date: int
+
+
+VoiceChatStarted = object
+
+
+class VoiceChatEnded(TypedDict):
+    duration: int
+
+
+class VoiceChatParticipantsInvited(TypedDict):
+    users: Optional[List[User]]
+
+
+class UserProfilePhotos(TypedDict):
+    total_count: int
+    photos: List[PhotoSize]
+
+
+class File(_BaseFile):
+    file_path: Optional[str]
+
+# If there's a better way to include the "from" key, please let me know
+Message = TypedDict(
+    "Message",
+    {
+        "message_id": int,
+        "from": Optional[User],
+        "sender_chat": Optional[Chat],
+        "date": int,
+        "chat": Chat,
+        "forward_from": Optional[Chat],
+        "forward_from_chat": Optional[int],
+        "forward_date": Optional[int],
+        "is_automatic_forward": Optional[Literal[True]],
+        "reply_to_message": Optional["Message"],
+        "via_bot": Optional[User],
+        "edit_date": Optional[int],
+        "has_protected_content": Optional[Literal[True]],
+        "media_group_id": Optional[str],
+        "author_signature": Optional[str],
+        "text": Optional[str],
+        "entities": Optional[List[MessageEntity]],
+        "animation": Optional[Animation] ,
+        "audio": Optional[Audio],
+        "document": Optional[Document],
+        "photo": Optional[List[PhotoSize]],
+        "sticker": Optional[Any],  # TODO
+        "video": Optional[Video],
+        "video_note": Optional[VideoNote],
+        "voice": Optional[Voice],
+        "caption": Optional[str],
+        "caption_entities": Optional[List[MessageEntity]],
+        "contact": Optional[Contact],
+        "dice": Optional[Dice],
+        "game": Optional[Any],  # TODO
+        "poll": Optional[Poll],
+        "venue": Optional[Venue],
+        "new_chat_members": Optional[List[User]],
+        "left_chat_member": Optional[User],
+        "new_chat_title": Optional[str],
+        "new_chat_photo": Optional[List[PhotoSize]],
+        "delete_chat_photo": Optional[Literal[True]],
+        "group_chat_created": Optional[Literal[True]],
+        "supergroup_chat_created": Optional[Literal[True]],
+        "channel_chat_created": Optional[Literal[True]],
+        "message_auto_delete_timer_changed": Optional[MessageAutoDeleteTimerChanged],
+        "migrate_to_chat_id": Optional[int],
+        "migrate_from_chat_id": Optional[int],
+        "pinned_message": Optional["Message"],
+        "invoice": Optional[Any],  # TODO
+        "successful_payment": Optional[Any],  # TODO
+        "connected_website": Optional[str],
+        "passport_data": Optional[Any],  # TODO
+        "proximity_alert_triggered": Optional[ProximityAlertTriggered],
+        "voice_chat_scheduled": Optional[VoiceChatScheduled],
+        "voice_chat_started": Optional[VoiceChatStarted],
+        "voice_chat_ended": Optional[VoiceChatEnded],
+        "voice_chat_participants_invited": Optional[VoiceChatParticipantsInvited],
+        "reply_markup": Optional[Any],  # TODO
+    }
+)

--- a/telegrampy/types/poll.py
+++ b/telegrampy/types/poll.py
@@ -24,10 +24,11 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import List, TypedDict
+from typing import TYPE_CHECKING, List, TypedDict
 
-from .message import MessageEntity
-from .user import User
+if TYPE_CHECKING:
+    from .message import MessageEntity
+    from .user import User
 
 
 class PollOption(TypedDict):

--- a/telegrampy/types/poll.py
+++ b/telegrampy/types/poll.py
@@ -1,7 +1,7 @@
 """
 MIT License
 
-Copyright (c) 2020 ilovetocode
+Copyright (c) 2020-2021 ilovetocode
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,41 +24,34 @@ SOFTWARE.
 
 from __future__ import annotations
 
-import re
-from typing import Literal
+from typing import List, TypedDict
 
-Version = Literal[1, 2]
-ParseMode = Literal["HTML", "Markdown", "MarkdownV2"]
+from .message import MessageEntity
+from .user import User
 
 
-def escape_markdown(text: str, *, version: Version = 2) -> str:
-    """Tool that escapes markdown from a given string.
+class PollOption(TypedDict):
+    text: str
+    voter_count: int
 
-    Parameters
-    ----------
-    text: :class:`str`
-        The text to escape markdown from.
-    version: Optional[:class:`int`]
-        The Telegram markdown version to use. Only 1 and 2 are supported.
 
-    Returns
-    -------
-    :class:`str`
-        The escaped text.
+class Poll(TypedDict):
+    id: str
+    question: str
+    options: List[PollOption]
+    total_voter_count: int
+    is_closed: bool
+    is_anonymous: bool
+    type: str
+    allows_multiple_answers: bool
+    correct_option_id: int
+    explanation: str
+    explanation_entries: List[MessageEntity]
+    open_period: int
+    close_date: int
 
-    Raises
-    ------
-    :exc:`ValueError`
-        An unsupported version was provided.
-    """
 
-    if version == 1:
-        characters = r"_*`["
-
-    elif version == 2:
-        characters = r"_*[]()~`>#+-=|{}.!"
-
-    else:
-        raise ValueError(f"Version '{version}' unsupported. Only version 1 and 2 are supported.")
-
-    return re.sub(f"([{re.escape(characters)}])", r"\\\1", text)
+class PollAnswer(TypedDict):
+    poll_id: str
+    user: User
+    option_ids: List[int]

--- a/telegrampy/types/user.py
+++ b/telegrampy/types/user.py
@@ -24,16 +24,16 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Optional, TypedDict
 
 
 class User(TypedDict):
     id: int
     is_bot: bool
     first_name: str
-    last_name: str
-    username: str
-    language_code: str
-    can_join_groups: bool
-    can_read_all_group_messages: bool
-    supports_inline_queries: bool
+    last_name: Optional[str]
+    username: Optional[str]
+    language_code: Optional[str]
+    can_join_groups: Optional[bool]
+    can_read_all_group_messages: Optional[bool]
+    supports_inline_queries: Optional[bool]

--- a/telegrampy/types/user.py
+++ b/telegrampy/types/user.py
@@ -1,7 +1,7 @@
 """
 MIT License
 
-Copyright (c) 2020 ilovetocode
+Copyright (c) 2020-2021 ilovetocode
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,41 +24,16 @@ SOFTWARE.
 
 from __future__ import annotations
 
-import re
-from typing import Literal
-
-Version = Literal[1, 2]
-ParseMode = Literal["HTML", "Markdown", "MarkdownV2"]
+from typing import TypedDict
 
 
-def escape_markdown(text: str, *, version: Version = 2) -> str:
-    """Tool that escapes markdown from a given string.
-
-    Parameters
-    ----------
-    text: :class:`str`
-        The text to escape markdown from.
-    version: Optional[:class:`int`]
-        The Telegram markdown version to use. Only 1 and 2 are supported.
-
-    Returns
-    -------
-    :class:`str`
-        The escaped text.
-
-    Raises
-    ------
-    :exc:`ValueError`
-        An unsupported version was provided.
-    """
-
-    if version == 1:
-        characters = r"_*`["
-
-    elif version == 2:
-        characters = r"_*[]()~`>#+-=|{}.!"
-
-    else:
-        raise ValueError(f"Version '{version}' unsupported. Only version 1 and 2 are supported.")
-
-    return re.sub(f"([{re.escape(characters)}])", r"\\\1", text)
+class User(TypedDict):
+    id: int
+    is_bot: bool
+    first_name: str
+    last_name: str
+    username: str
+    language_code: str
+    can_join_groups: bool
+    can_read_all_group_messages: bool
+    supports_inline_queries: bool

--- a/telegrampy/user.py
+++ b/telegrampy/user.py
@@ -29,6 +29,7 @@ import io
 from typing import TYPE_CHECKING, Optional, Union
 
 from .abc import TelegramObject
+from .mixins import Hashable
 from .utils import escape_markdown
 
 if TYPE_CHECKING:
@@ -40,7 +41,7 @@ if TYPE_CHECKING:
 
 
 
-class User(TelegramObject):
+class User(TelegramObject, Hashable):
     """
     Represents a Telegram user.
 
@@ -67,11 +68,11 @@ class User(TelegramObject):
     first_name: :class:`str`
         The first name of the user.
     last_name: Optional[:class:`str`]
-        The last name of the user.
+        The last name of the user, if applicable.
     username: Optional[:class:`str`]
-        The username of the user.
+        The username of the user, if applicable.
     language_code: Optional[:class:`str`]
-        The IETF language tag for the user's language.
+        The IETF language tag for the user's language, if applicable.
     can_join_groups: Optional[:class:`bool`]
         If the bot can join groups. Only returned in :class:`telegrampy.Client.get_me`.
     can_read_all_group_messages: Optional[:class:`bool`]
@@ -81,27 +82,29 @@ class User(TelegramObject):
     """
 
     if TYPE_CHECKING:
+        id: int
         is_bot: bool
-        username: str
+        username: Optional[str]
         first_name: str
-        last_name: str
-        language_code: str
-        can_join_groups: bool
-        can_read_all_group_messages: bool
-        supports_inline_queries: bool
+        last_name: Optional[str]
+        language_code: Optional[str]
+        can_join_groups: Optional[bool]
+        can_read_all_group_messages: Optional[bool]
+        supports_inline_queries: Optional[bool]
 
     def __init__(self, http: HTTPClient, data: UserPayload) -> None:
-        super().__init__(http, data)
+        super().__init__(http)
+        self.id: int = data.get("id")
         self.is_bot: bool = data.get("is_bot")
-        self.username: str = data.get("username")
+        self.username: Optional[str] = data.get("username")
         self.first_name: str = data.get("first_name")
-        self.last_name: str = data.get("last_name")
-        self.language_code: str = data.get("language_code")
-        self.can_join_groups: bool = data.get("can_join_groups")
-        self.can_read_all_group_messages: bool = data.get("can_read_all_group_messages")
-        self.supports_inline_queries: bool = data.get("supports_inline_queries")
+        self.last_name: Optional[str] = data.get("last_name")
+        self.language_code: Optional[str] = data.get("language_code")
+        self.can_join_groups: Optional[bool] = data.get("can_join_groups")
+        self.can_read_all_group_messages: Optional[bool] = data.get("can_read_all_group_messages")
+        self.supports_inline_queries: Optional[bool] = data.get("supports_inline_queries")
 
-    def __str__(self) -> str:
+    def __str__(self) -> Optional[str]:
         return self.username
 
     @property

--- a/telegrampy/user.py
+++ b/telegrampy/user.py
@@ -39,11 +39,8 @@ if TYPE_CHECKING:
     from .types.user import User as UserPayload
 
 
-
-
 class User(TelegramObject, Hashable):
-    """
-    Represents a Telegram user.
+    """Represents a Telegram user.
 
     .. container:: operations
 
@@ -109,34 +106,24 @@ class User(TelegramObject, Hashable):
 
     @property
     def name(self) -> str:
-        """
-        :class:`str`:
-            Username if the user has one. Otherwise the full name of the user.
-        """
+        """:class:`str`: Username if the user has one. Otherwise the full name of the user."""
 
         return self.username or self.full_name
 
     @property
     def full_name(self) -> str:
-        """
-        :class:`str`:
-            The user's full name.
-        """
+        """:class:`str`: The user's full name."""
 
         return f"{self.first_name} {self.last_name}" if self.last_name else self.first_name
 
     @property
     def link(self) -> Optional[str]:
-        """
-        Optional[:class:`str`]:
-            The t.me link for the user, if applicable.
-        """
+        """Optional[:class:`str`]: The t.me link for the user, if applicable."""
 
         return f"http://t.me/{self.username}" if self.username else None
 
     def mention(self, text: Optional[str] = None, parse_mode: ParseMode = "HTML") -> str:
-        """
-        Returns a mention for the user.
+        """Returns a mention for the user.
 
         Parameters
         ----------

--- a/telegrampy/user.py
+++ b/telegrampy/user.py
@@ -22,12 +22,23 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from __future__ import annotations
+
 import html
 import io
-import typing
+from typing import TYPE_CHECKING, Optional, Union
 
 from .abc import TelegramObject
 from .utils import escape_markdown
+
+if TYPE_CHECKING:
+    from .http import HTTPClient
+    from .message import Message
+    from .utils import ParseMode
+    from .types.user import User as UserPayload
+
+
+
 
 class User(TelegramObject):
     """
@@ -69,22 +80,32 @@ class User(TelegramObject):
         If the bot has inline queries enabled. Only returned in :class:`telegrampy.Client.get_me`.
     """
 
-    def __init__(self, http, data):
-        super().__init__(http, data)
-        self.is_bot = data.get("is_bot")
-        self.username = data.get("username")
-        self.first_name = data.get("first_name")
-        self.last_name = data.get("last_name")
-        self.language_code = data.get("language_code")
-        self.can_join_groups = data.get("can_join_groups")
-        self.can_read_all_group_messages = data.get("can_read_all_group_messages")
-        self.supports_inline_queries = data.get("supports_inline_queries")
+    if TYPE_CHECKING:
+        is_bot: bool
+        username: str
+        first_name: str
+        last_name: str
+        language_code: str
+        can_join_groups: bool
+        can_read_all_group_messages: bool
+        supports_inline_queries: bool
 
-    def __str__(self):
+    def __init__(self, http: HTTPClient, data: UserPayload) -> None:
+        super().__init__(http, data)
+        self.is_bot: bool = data.get("is_bot")
+        self.username: str = data.get("username")
+        self.first_name: str = data.get("first_name")
+        self.last_name: str = data.get("last_name")
+        self.language_code: str = data.get("language_code")
+        self.can_join_groups: bool = data.get("can_join_groups")
+        self.can_read_all_group_messages: bool = data.get("can_read_all_group_messages")
+        self.supports_inline_queries: bool = data.get("supports_inline_queries")
+
+    def __str__(self) -> str:
         return self.username
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         :class:`str`:
             Username if the user has one. Otherwise the full name of the user.
@@ -93,7 +114,7 @@ class User(TelegramObject):
         return self.username or self.full_name
 
     @property
-    def full_name(self):
+    def full_name(self) -> str:
         """
         :class:`str`:
             The user's full name.
@@ -102,15 +123,15 @@ class User(TelegramObject):
         return f"{self.first_name} {self.last_name}" if self.last_name else self.first_name
 
     @property
-    def link(self):
+    def link(self) -> Optional[str]:
         """
-        :class:`str`:
-            The t.me link for the user.
+        Optional[:class:`str`]:
+            The t.me link for the user, if applicable.
         """
 
         return f"http://t.me/{self.username}" if self.username else None
 
-    def mention(self, text = None, parse_mode = "HTML"):
+    def mention(self, text: Optional[str] = None, parse_mode: ParseMode = "HTML") -> str:
         """
         Returns a mention for the user.
 
@@ -137,9 +158,9 @@ class User(TelegramObject):
         elif parse_mode == "MarkdownV2":
             return f"[{escape_markdown(text, version=2)}](tg://user?id={self.id})"
 
-    async def send(self, content: str = None, parse_mode: str = None):
+    async def send(self, content: str, parse_mode: Optional[ParseMode] = None) -> Message:
         """|coro|
-        
+
         Sends a message to the user.
 
         Parameters
@@ -162,7 +183,13 @@ class User(TelegramObject):
 
         return await self._http.send_message(chat_id=self.id, content=content, parse_mode=parse_mode)
 
-    async def send_document(self, document: typing.Union[io.BytesIO, str], filename: str = None, caption: str = None, parse_mode: str = None):
+    async def send_document(
+        self,
+        document: Union[io.BytesIO, str],
+        filename: Optional[str] = None,
+        caption: Optional[str] = None,
+        parse_mode: Optional[ParseMode] = None
+    ) -> Message:
         """|coro|
 
         Sends a document to the user.
@@ -191,7 +218,13 @@ class User(TelegramObject):
 
         return await self._http.send_document(chat_id=self.id, file=document, filename=filename, caption=caption, parse_mode=parse_mode)
 
-    async def send_photo(self, photo: typing.Union[io.BytesIO, str], filename: str = None, caption: str = None, parse_mode: str = None):
+    async def send_photo(
+        self,
+        photo: Union[io.BytesIO, str],
+        filename: Optional[str] = None,
+        caption: Optional[str] = None,
+        parse_mode: Optional[str] = None
+    ) -> Message:
         """|coro|
 
         Sends a photo to the user.
@@ -214,8 +247,8 @@ class User(TelegramObject):
         """
 
         if isinstance(photo, str):
-            with open(document, "rb") as file:
+            with open(photo, "rb") as file:
                 content = file.read()
-                document = io.BytesIO(content)
+                photo = io.BytesIO(content)
 
         return await self._http.send_photo(chat_id=self.id, file=photo, filename=filename, caption=caption, parse_mode=parse_mode)


### PR DESCRIPTION
This pull request:
* adds typehints to the library (it should be type-complete).
  * adds semi-complete Telegram Bot API types (located in `telegrampy/types`).
     these types can be used to add remaining bot API functionality to the library.
* fixes longstanding library bugs.
* fixes some docstrings.
* adds `telegrampy/mixins.py`, which provides mixins that are used for the data classes.
* refactors `TelegramObject` to only accept an `HTTPClient`.
* adds a `MANIFEST.in` file, which is necessary to ship typing metadata (`py.typed`).
* improves PEP-8 compliance
* and more that I may be forgetting.

This pull request is marked as draft because it hasn't been fully tested yet. There are also a few more things I'd like to do.